### PR TITLE
Optional dimension filter

### DIFF
--- a/src/spxmod/dimension.py
+++ b/src/spxmod/dimension.py
@@ -14,8 +14,9 @@ class Dimension:
 
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, filter: str | None = None) -> None:
         self.name = name
+        self.filter = filter
         self._span: NDArray | None = None
 
     @property
@@ -37,7 +38,10 @@ class Dimension:
             Data to set the unique dimension values from.
 
         """
-        self._span = np.unique(data[self.name])
+        if self.filter is None:
+            self._span = np.unique(data[self.name])
+        else:
+            self._span = np.unique(data.query(self.filter)[self.name])
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(name={self.name})"
@@ -100,7 +104,9 @@ class NumericalDimension(Dimension):
         return sd
 
 
-def build_dimension(name: str, dim_type: str) -> Dimension:
+def build_dimension(
+    name: str, dim_type: str, filter: str | None = None
+) -> Dimension:
     """Create a dimension based on the dimension type.
 
     Parameters
@@ -117,8 +123,8 @@ def build_dimension(name: str, dim_type: str) -> Dimension:
 
     """
     if dim_type == "categorical":
-        return CategoricalDimension(name)
+        return CategoricalDimension(name, filter)
     elif dim_type == "numerical":
-        return NumericalDimension(name)
+        return NumericalDimension(name, filter)
     else:
         raise TypeError(f"Dimension type {dim_type} is not supported.")

--- a/src/spxmod/dimension.py
+++ b/src/spxmod/dimension.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.sparse import coo_matrix
+
 from spxmod.typing import DataFrame, NDArray
 
 

--- a/src/spxmod/space.py
+++ b/src/spxmod/space.py
@@ -5,6 +5,7 @@ import itertools
 
 import numpy as np
 from scipy.sparse import coo_matrix, identity, kron, vstack
+
 from spxmod.dimension import Dimension, NumericalDimension, build_dimension
 from spxmod.typing import DataFrame, NDArray
 

--- a/src/spxmod/space.py
+++ b/src/spxmod/space.py
@@ -5,7 +5,6 @@ import itertools
 
 import numpy as np
 from scipy.sparse import coo_matrix, identity, kron, vstack
-
 from spxmod.dimension import Dimension, NumericalDimension, build_dimension
 from spxmod.typing import DataFrame, NDArray
 
@@ -115,7 +114,10 @@ class Space:
                 .eval("index")
                 .to_numpy()
             )
-        return coo_matrix((val, (row, col)), shape=(len(data), self.size))
+        index = ~np.isnan(col)
+        return coo_matrix(
+            (val[index], (row[index], col[index])), shape=(len(data), self.size)
+        )
 
     def build_smoothing_prior(
         self,


### PR DESCRIPTION
Adding dimension filter so we can create `location_id*age_mid` intercepts only where `location_id != national_id` in onemod model.

I tested that the number of variables expected is correct and that it runs. Take a look to make sure my changes make sense!