### PR TITLE
Add order prior constraints

### DIFF
--- a/src/spxmod/dimension.py
+++ b/src/spxmod/dimension.py
@@ -99,6 +99,13 @@ class NumericalDimension(Dimension):
             sd *= delta
         return sd
 
+    def build_order_mat(self, order: list[list[int]]) -> coo_matrix:
+        size = len(order)
+        val = np.hstack([np.ones(size - 1), -np.ones(size - 1)])
+        row = np.tile(np.arange(size - 1), 2)
+        col = np.hstack([order[:-1], order[1:]])
+        return coo_matrix((val, (row, col)), shape=(size - 1, self.size))
+
 
 def build_dimension(name: str, dim_type: str) -> Dimension:
     """Create a dimension based on the dimension type.

--- a/src/spxmod/model.py
+++ b/src/spxmod/model.py
@@ -105,6 +105,8 @@ class XModel:
             data=dict(col_obs=obs, col_weights=weights),
             variables=[],
             linear_gpriors=[],
+            linear_upriors=[],
+            param_specs=param_specs or {},
         )
         if param_specs is not None:
             self.core_config.update(param_specs)
@@ -134,6 +136,7 @@ class XModel:
 
         self.core_config["variables"] = self._build_variables()
         self.core_config["linear_gpriors"] = self._build_linear_gpriors()
+        self.core_config["linear_upriors"] = self._build_linear_upriors()
 
     def _build_variables(self) -> list[dict]:
         variables = []
@@ -148,6 +151,14 @@ class XModel:
             mat.append(prior["mat"]), sd.append(prior["sd"])
         mat, sd = block_diag(mat), np.hstack(sd)
         return [dict(mat=mat, mean=0.0, sd=sd)]
+
+    def _build_linear_upriors(self) -> list[dict]:
+        mat = []
+        for var_builder in self.var_builders:
+            prior = var_builder.build_order_prior()
+            mat.append(prior["mat"])
+        mat = block_diag(mat)
+        return [dict(mat=mat, lb=-np.inf, ub=0.0)]
 
     def _build_core(self) -> RegmodModel:
         return build_regmod_model(**self.core_config)

--- a/src/spxmod/space.py
+++ b/src/spxmod/space.py
@@ -176,6 +176,27 @@ class Space:
         # be necessary in the future
         return dict(mat=mat, sd=sd)
 
+    def build_order_prior(
+        self,
+        order_dim: str = "",
+        order: list[list[int]] | None = None,
+    ) -> dict[str, NDArray]:
+        mat = coo_matrix((0, self.size))
+        if order_dim == "":
+            return dict(mat=mat)
+
+        mats_default = list(map(identity, self.dim_sizes))
+
+        for i, dim in enumerate(self.dims):
+            if dim.name == order_dim and isinstance(dim, NumericalDimension):
+                mats = mats_default.copy()
+                mats[i] = vstack(
+                    [dim.build_order_mat(order_item) for order_item in order]
+                )
+                mat = vstack([mat, functools.reduce(kron, mats)])
+
+        return dict(mat=mat)
+
 
 def _flatten_outer(x: NDArray, y: NDArray) -> NDArray:
     """Flatten the outer product of two arrays.

--- a/src/spxmod/variable_builder.py
+++ b/src/spxmod/variable_builder.py
@@ -61,6 +61,8 @@ class VariableBuilder:
         space: Space = Space(),
         lam: float | dict[str, float] = 0.0,
         lam_mean: float = 0.0,
+        order_dim: str = "",
+        order: list[list[int]] | None = None,
         gprior: dict[str, float] | None = None,
         uprior: dict[str, float] | None = None,
         scale_by_distance: bool = False,
@@ -72,6 +74,8 @@ class VariableBuilder:
         self.space = space
         self.lam = lam
         self.lam_mean = lam_mean
+        self.order_dim = order_dim
+        self.order = order
         self.gprior = gprior or dict(mean=0.0, sd=np.inf)
         self.uprior = uprior or dict(lb=-np.inf, ub=np.inf)
         self.scale_by_distance = scale_by_distance
@@ -151,6 +155,9 @@ class VariableBuilder:
         return self.space.build_smoothing_prior(
             size, self.lam, self.lam_mean, self.scale_by_distance
         )
+
+    def build_order_prior(self) -> dict[str, NDArray]:
+        return self.space.build_order_prior(self.order_dim, self.order)
 
     def encode(self, data: DataFrame) -> DataFrame:
         """Encode variable column based on the space.


### PR DESCRIPTION
## Description

During the mortality estimation practice, we realize that to regularize the fit, we need constraints on the value on the grid. This feature allows user to specify the order of the value on the grid. For example, we can add constraints that the value for age 85 is less than the value for age 100.

## Changes

* Add `build_order_mat` method to `Dimension` class
* Open up `linear_uprior` option for the Customized Regmod model
* Create the port for adding the order prior from `VariableBuilder`

## Example

To extra arguments for `VariableBuilder` are `order_dim` and `order`, which corresponding to which dimension the order applies to and the order in the ascending order.

```yaml
var_builders:
- name: intercept
    space: age_mid
    lam: 25.0
    order_dim: age_mid
    order: [[22, 23, 24]]
- name: intercept
    space: super_region_id*age_mid
    lam: 1000.0
    order_dim: age_mid
    order: [[22, 23, 24]]
```
And the `22, 23, 24` in the order corresponding to the index for the grid/span in the dimension object.